### PR TITLE
Search pagination and scoring

### DIFF
--- a/src/deserialization/search_deserializer.rs
+++ b/src/deserialization/search_deserializer.rs
@@ -1,4 +1,4 @@
-use crate::entity::search::{SearchResult, Searchable};
+use crate::entity::search::{SearchEntity, SearchResult, Searchable};
 use chrono::NaiveDateTime;
 use serde::de::DeserializeOwned;
 use serde::de::{self, Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
@@ -114,7 +114,7 @@ where
                 let mut created: Option<String> = None;
                 let mut count: Option<i32> = None;
                 let mut offset: Option<i32> = None;
-                let mut entities: Option<Vec<T>> = None;
+                let mut entities: Option<Vec<SearchEntity<T>>> = None;
 
                 while let Some(key) = map.next_key::<Field<T>>()? {
                     match key {

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -41,7 +41,7 @@ macro_rules! impl_includes {
 
         impl SearchQuery<$ty> {
                $(pub fn $args(&mut self) -> &mut Self  {
-                     self.0.include = self.0.include($inc).include.to_owned();
+                     self.inner.include = self.inner.include($inc).include.to_owned();
                    self
                })*
             }

--- a/src/entity/search.rs
+++ b/src/entity/search.rs
@@ -29,7 +29,7 @@ pub struct SearchResult<T> {
 pub struct SearchEntity<T> {
     pub score: Option<String>,
     #[serde(flatten)]
-    inner: T,
+    pub inner: T,
 }
 
 impl<T> Deref for SearchEntity<T> {

--- a/src/entity/search.rs
+++ b/src/entity/search.rs
@@ -1,3 +1,5 @@
+use std::ops::{Deref, DerefMut};
+
 use crate::entity::annotation::Annotation;
 use crate::entity::area::Area;
 use crate::entity::artist::Artist;
@@ -11,7 +13,7 @@ use crate::entity::release_group::ReleaseGroup;
 use crate::entity::series::Series;
 use crate::entity::work::Work;
 use chrono::NaiveDateTime;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, PartialEq, Eq, Clone)]
 #[serde(rename_all(deserialize = "kebab-case"))]
@@ -19,7 +21,28 @@ pub struct SearchResult<T> {
     pub created: NaiveDateTime,
     pub count: i32,
     pub offset: i32,
-    pub entities: Vec<T>,
+    pub entities: Vec<SearchEntity<T>>,
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone)]
+/// score is an external field added only on search results
+pub struct SearchEntity<T> {
+    pub score: Option<String>,
+    #[serde(flatten)]
+    inner: T,
+}
+
+impl<T> Deref for SearchEntity<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T> DerefMut for SearchEntity<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
 }
 
 pub trait Searchable {

--- a/src/entity/search.rs
+++ b/src/entity/search.rs
@@ -15,7 +15,7 @@ use crate::entity::work::Work;
 use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, PartialEq, Eq, Clone)]
+#[derive(Debug, Serialize, PartialEq, Clone)]
 #[serde(rename_all(deserialize = "kebab-case"))]
 pub struct SearchResult<T> {
     pub created: NaiveDateTime,
@@ -24,10 +24,10 @@ pub struct SearchResult<T> {
     pub entities: Vec<SearchEntity<T>>,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
 /// score is an external field added only on search results
 pub struct SearchEntity<T> {
-    pub score: Option<String>,
+    pub score: Option<f32>,
     #[serde(flatten)]
     pub inner: T,
 }


### PR DESCRIPTION
My bad for this second PR, but I also think it's better to separate concepts.
This PR is kind-of more invasive than the previous, it introduces pagination on search queries and, to not insert a `score` field in every entity, introduces a `SearchEntity` wrapper that leverages serde's flatten to be transparent on deserialization.

What I don't really like here is having `inner` field as public, since its fields are already accessible via Deref and DerefMut.
What do you think about it? Maybe an `impl<T> Into<T> for SearchEntity<T>` would be better?