### PR TITLE
feat(release): support `media` and `discid` subqueries

### DIFF
--- a/src/entity/release.rs
+++ b/src/entity/release.rs
@@ -2082,7 +2082,8 @@ impl_includes!(
     (
         with_artist_credits,
         Include::Subquery(Subquery::ArtistCredits)
-    )
+    ),
+    (with_media, Include::Subquery(Subquery::Media))
 );
 
 // Relationships includes

--- a/src/entity/release.rs
+++ b/src/entity/release.rs
@@ -2083,7 +2083,8 @@ impl_includes!(
         with_artist_credits,
         Include::Subquery(Subquery::ArtistCredits)
     ),
-    (with_media, Include::Subquery(Subquery::Media))
+    (with_media, Include::Subquery(Subquery::Media)),
+    (with_discids, Include::Subquery(Subquery::DiscIds))
 );
 
 // Relationships includes

--- a/tests/async_tests/release/release_includes.rs
+++ b/tests/async_tests/release/release_includes.rs
@@ -22,7 +22,7 @@ async fn should_get_release_release_groups() {
 async fn should_get_release_media() {
     let justice_cross = Release::fetch()
         .id("4642ee19-7790-3c8d-ab5e-d133de942db6")
-        .with_recordings()
+        .with_media()
         .execute()
         .await
         .unwrap();

--- a/tests/async_tests/release/release_includes.rs
+++ b/tests/async_tests/release/release_includes.rs
@@ -36,6 +36,27 @@ async fn should_get_release_media() {
 
 #[tokio::test]
 #[serial_test::serial]
+async fn should_get_release_discids() {
+    let justice_cross = Release::fetch()
+        .id("4642ee19-7790-3c8d-ab5e-d133de942db6")
+        .with_discids()
+        .execute()
+        .await
+        .unwrap();
+
+    let medias: Vec<Media> = justice_cross.media.unwrap();
+    let cd = medias.first().unwrap();
+
+    assert!(cd
+        .discs
+        .as_ref()
+        .unwrap()
+        .iter()
+        .any(|disc| disc.id == "TNLYkkUzaFr9BejILb6fsUaDjcg-"));
+}
+
+#[tokio::test]
+#[serial_test::serial]
 async fn should_get_release_recordings() {
     let justice_cross = Release::fetch()
         .id("4642ee19-7790-3c8d-ab5e-d133de942db6")

--- a/tests/blocking_tests/release/release_includes.rs
+++ b/tests/blocking_tests/release/release_includes.rs
@@ -19,7 +19,7 @@ fn should_get_release_release_groups() {
 fn should_get_release_media() {
     let justice_cross = Release::fetch()
         .id("4642ee19-7790-3c8d-ab5e-d133de942db6")
-        .with_recordings()
+        .with_media()
         .execute()
         .unwrap();
 

--- a/tests/blocking_tests/release/release_includes.rs
+++ b/tests/blocking_tests/release/release_includes.rs
@@ -31,6 +31,25 @@ fn should_get_release_media() {
 }
 
 #[test]
+fn should_get_release_discids() {
+    let justice_cross = Release::fetch()
+        .id("4642ee19-7790-3c8d-ab5e-d133de942db6")
+        .with_discids()
+        .execute()
+        .unwrap();
+
+    let medias: Vec<Media> = justice_cross.media.unwrap();
+    let cd = medias.first().unwrap();
+
+    assert!(cd
+        .discs
+        .as_ref()
+        .unwrap()
+        .iter()
+        .any(|disc| disc.id == "TNLYkkUzaFr9BejILb6fsUaDjcg-"));
+}
+
+#[test]
 fn should_get_release_recordings() {
     let justice_cross = Release::fetch()
         .id("4642ee19-7790-3c8d-ab5e-d133de942db6")


### PR DESCRIPTION
This PR extends the list of subqueries allowed for releases to include `media` and `discids`.

Prior to this PR the `media` could be included implicitly via the `recordings` subquery, but now it can be specified specifically.