### PR TITLE
feat: add support for ISNI/IPI on Artist

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Cargo.lock
 api_samples/
 .idea/
+/.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751271578,
+        "narHash": "sha256-P/SQmKDu06x8yv7i0s8bvnnuJYkxVGBWLWHaU+tt4YY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3016b4b15d13f3089db8a41ef937b13a9e33a8df",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1751338093,
+        "narHash": "sha256-/yd9nPcTfUZPFtwjRbdB5yGLdt3LTPqz6Ja63Joiahs=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "6cfb7821732dac2d3e2dea857a5613d3b856c20c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,44 @@
+{
+  description = "Rust devShell";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      rust-overlay,
+      flake-utils,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+      in
+      {
+        devShells.default =
+          with pkgs;
+          mkShell {
+            buildInputs = [
+              openssl
+              pkg-config
+              (rust-bin.stable.latest.default.override {
+                extensions = [
+                  "cargo"
+                  "clippy"
+                  "rust-src"
+                  "rust-analyzer"
+                ];
+              })
+            ];
+          };
+      }
+    );
+}

--- a/src/entity/artist.rs
+++ b/src/entity/artist.rs
@@ -54,6 +54,11 @@ pub struct Artist {
     /// identified with. It is often, but not always, its birth/formation country.
     pub area: Option<Area>,
 
+    /// An IPI (interested party information) code is an identifying number assigned by the CISAC database for musical rights management. See [IPI](https://musicbrainz.org/doc/IPI) for more information, including how to find these codes.
+    pub ipis: Option<Vec<String>>,
+    /// The International Standard Name Identifier for the artist. See [ISNI](https://musicbrainz.org/doc/ISNI) for more information.
+    pub isnis: Option<Vec<String>>,
+
     ///The artist begin area, as the name suggests, indicates the area with which an artist started
     /// to perform.
     #[serde(rename = "begin_area")] // Forcing camel_case here since

--- a/tests/async_tests/api/fetch.rs
+++ b/tests/async_tests/api/fetch.rs
@@ -319,7 +319,7 @@ async fn should_get_label_by_id() {
             label_type: Some(LabelType::OriginalProduction),
             name: "Ninja Tune".to_string(),
             sort_name: Some("Ninja Tune".to_string()),
-            disambiguation: Some("London-based label".to_string()),
+            disambiguation: Some("London‐based label".to_string()),
             country: Some("GB".to_string()),
             label_code: Some(12885),
             relations: None,

--- a/tests/async_tests/api/fetch.rs
+++ b/tests/async_tests/api/fetch.rs
@@ -54,6 +54,11 @@ async fn should_get_artist_by_id() {
                 genres: None,
                 annotation: None,
             }),
+            isnis: Some(vec![
+                "0000000123486830".to_string(),
+                "0000000123487390".to_string()
+            ]),
+            ipis: Some(vec![]),
             begin_area: None,
             life_span: Some(LifeSpan {
                 ended: Some(true),
@@ -99,6 +104,8 @@ async fn should_get_artist_relations_from_release() {
                 artist_type: Some(Person),
                 gender: None,
                 area: None,
+                ipis: None,
+                isnis: None,
                 begin_area: None,
                 relations: None,
                 releases: None,


### PR DESCRIPTION
We plan to use this repo to work with musicbrainz data, but we need to retrieve the IPI/ISNI of the artists, which is currently missing on the Artist type of this repo.

This PR add the required fields and also fix a non-related to changes test failing due to having the wrong character separator on the assert.