### PR TITLE
feat: allow customizing MusicBrainz endpoints https and authority

### DIFF
--- a/examples/netrc.rs
+++ b/examples/netrc.rs
@@ -5,7 +5,7 @@ use musicbrainz_rs::prelude::*;
 #[macro_rules_attribute::apply(smol_macros::main!)]
 async fn main() {
     let client = MusicBrainzClient::builder()
-        .musicbrainz_domain("musicbrainz.org".to_string())
+        .musicbrainz_authority("musicbrainz.org".to_string())
         .netrc_auth()
         .build();
 

--- a/src/api/endpoints.rs
+++ b/src/api/endpoints.rs
@@ -4,26 +4,35 @@ use api_bindium::endpoints::path::EndpointUriBuilderPath;
 /// Endpoints for the api
 #[derive(Debug, bon::Builder, Clone)]
 pub struct MusicBrainzAPIEnpoints {
-    /// The domain of the server.
-    ///
-    /// Please note that all the api endpoints must be accessed by HTTPS.
+    /// Whether to use HTTPS. Defaults to `true`.
+    #[builder(default = true)]
+    use_https: bool,
+
+    /// The authority (host and optional port) of the server,
+    /// e.g. `musicbrainz.org` or `localhost:5000`.
     #[builder(default = "musicbrainz.org".to_string())]
-    domain: String,
+    authority: String,
 }
 
 impl MusicBrainzAPIEnpoints {
-    /// The api root
+    /// The api root URL
     pub fn api_root(&self) -> String {
-        format!("https://{}", self.domain)
+        format!(
+            "{}://{}",
+            if self.use_https { "https" } else { "http" },
+            self.authority,
+        )
     }
 
-    /// Return an endpoint builder for endpoints
-    ///
-    /// The scheme and domain are already set
+    /// Return an endpoint builder with the scheme and authority already set
     pub fn endpoint_builder(&self) -> EndpointUriBuilder<EndpointUriBuilderPath> {
-        EndpointUriBuilder::new()
-            .https()
-            .set_authority(&self.domain)
+        let builder = EndpointUriBuilder::new();
+        if self.use_https {
+            builder.https()
+        } else {
+            builder.http()
+        }
+        .set_authority(&self.authority)
     }
 }
 

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -31,9 +31,9 @@ impl<T> Query<T> {
         &self,
         client: &MusicBrainzClient,
     ) -> EndpointUriBuilder<EndpointUriBuilderQuery> {
-        let url = EndpointUriBuilder::new()
-            .http()
-            .set_authority(&client.musicbrainz_domain)
+        let url = client
+            .endpoints()
+            .endpoint_builder()
             .add_path_fragment("ws/2")
             .add_path_fragment(&self.path)
             .query()

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -33,9 +33,13 @@ pub struct MusicBrainzClient {
     #[builder(default = MusicBrainzClient::default_api_client())]
     pub api_client: ApiClient,
 
-    /// Domain of the api
-    #[builder(default = "musicbrainz.org".to_string(), getter)]
-    pub musicbrainz_domain: String,
+    /// Whether to use HTTPS for the MusicBrainz API. Defaults to `true`.
+    #[builder(default = true)]
+    pub musicbrainz_use_https: bool,
+
+    /// Authority (host and optional port) of the API.
+    #[builder(default = "musicbrainz.org".to_string())]
+    pub musicbrainz_authority: String,
 
     /// Domain of the cover art archive api
     #[builder(default = "http://coverartarchive.org".to_string())]
@@ -95,7 +99,8 @@ impl MusicBrainzClient {
     /// Return a struct with the endpoints of the api
     pub fn endpoints(&self) -> MusicBrainzAPIEnpoints {
         MusicBrainzAPIEnpoints::builder()
-            .domain(self.musicbrainz_domain.clone())
+            .use_https(self.musicbrainz_use_https)
+            .authority(self.musicbrainz_authority.clone())
             .build()
     }
 }


### PR DESCRIPTION
This replaces the previously hardcoded https & extends the "domain" into a more flexible authority to allow setting a custom port (mirroring api_bindium).